### PR TITLE
Fix coredns "cannot find package" build errors #591

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,10 +25,9 @@ compile:
   image: crosscloudci/debian-go
   stage: build
   script:
-    - sleep 20000
     - ln -s /builds /go/src/github.com
     - cd /go/src/github.com/coredns/coredns
-    - make -j $(getconf _NPROCESSORS_ONLN) all
+    - make all
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,12 +22,11 @@ before_script:
   # - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
 
 compile:
-  # image: crosscloudci/debian-go
-  image: golang:stretch
+  image: crosscloudci/debian-go
   stage: build
   script:
-    # - ln -s /builds /go/src/github.com
-    - sleep 1000000
+    - ln -s /builds /go/src/github.com
+    - cd /go/src/github.com/coredns/coredns
     - make -j $(getconf _NPROCESSORS_ONLN) all
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,7 @@ compile:
   image: crosscloudci/debian-go
   stage: build
   script:
+    - sleep 20000
     - ln -s /builds /go/src/github.com
     - cd /go/src/github.com/coredns/coredns
     - make -j $(getconf _NPROCESSORS_ONLN) all

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ compile:
   image: golang:stretch
   stage: build
   script:
-    - ln -s /builds /go/src/github.com
+    # - ln -s /builds /go/src/github.com
     - sleep 1000000
     - make -j $(getconf _NPROCESSORS_ONLN) all
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,13 +19,15 @@ before_script:
     else
       export CROSS_CLOUD_YML="$CROSS_CLOUD_YML"
     fi
-  - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
+  # - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
 
 compile:
-  image: crosscloudci/debian-go
+  # image: crosscloudci/debian-go
+  image: golang:stretch
   stage: build
   script:
     - ln -s /builds /go/src/github.com
+    - sleep 1000000
     - make -j $(getconf _NPROCESSORS_ONLN) all
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ before_script:
     else
       export CROSS_CLOUD_YML="$CROSS_CLOUD_YML"
     fi
-  # - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
+  - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
 
 compile:
   image: crosscloudci/debian-go

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,7 @@ compile:
   script:
     - ln -s /builds /go/src/github.com
     - cd /go/src/github.com/coredns/coredns
+    - make godeps
     - make all
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"


### PR DESCRIPTION
We now need to fetch go deps explicitly with "make godeps" and build in the full coredns go directory.