### PR TITLE
#77 replace png with svg logo

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,5 +1,5 @@
 project:
-  logo_url: "https://raw.githubusercontent.com/cncf/artwork/1d4e7cf3b60af40e008b2e2413f7a2d1ff784b52/coredns/icon/color/core-dns-icon-color.png"
+  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/coredns/icon/color/coredns-icon-color.svg?sanitize=true"
   display_name: CoreDNS
   sub_title: Service Discovery
   project_url: "https://github.com/coredns/coredns" 


### PR DESCRIPTION
https://github.com/crosscloudci/ci-dashboard/issues/77

Changes made: 
  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/coredns/icon/color/coredns-icon-color.svg?sanitize=true"