### PR TITLE
Add support for separate environments for status results - K8s drop-down selection

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,8 @@ before_script:
 compile:
   image: crosscloudci/debian-go
   stage: build
+  tags:
+    - aufs
   script:
     - ln -s /builds /go/src/github.com
     - cd /go/src/github.com/coredns/coredns
@@ -49,8 +51,10 @@ compile:
       - ./coredns
 
 container:
-  stage: package
   image: crosscloudci/debian-docker 
+  stage: package
+  tags:
+    - aufs
   script:
     - IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}
     - cp build/Linux/coredns . || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,6 +77,7 @@ container:
       else
         echo 'Default to amd64 (Intel)'
         export IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.amd64
+      fi
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
     - docker build --pull -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,19 +30,33 @@ compile:
     - ln -s /builds /go/src/github.com
     - cd /go/src/github.com/coredns/coredns
     - GO111MODULE=on go mod download
-    - make all
     - >
-      if [ "$CI_COMMIT_REF_NAME" == "master" ]; then
-        make TEST_TYPE=coverage travis
-        make TEST_TYPE=integration travis
-        make TEST_TYPE=core travis
-        make TEST_TYPE=plugin travis
+      if [ "$ARCH" == "arm64" ]; then
+        echo 'ARCH set to arm64'
+        make all SYSTEM="GOOS=linux GOARCH=arm64"
       else
-        make TEST_TYPE=coverage travis || true
-        make TEST_TYPE=integration travis || true
-        make TEST_TYPE=core travis || true
-        make TEST_TYPE=plugin travis || true
+        echo 'Default to amd64 (Intel)'
+        make all
       fi
+    - >
+      if [ "$ARCH" == "arm64" ]; then
+        echo 'SKIP unit tests for arm64'
+      else
+        echo 'Running unit tests for amd64'
+        if [ "$CI_COMMIT_REF_NAME" == "master" ]; then
+          make TEST_TYPE=coverage travis
+          make TEST_TYPE=integration travis
+          make TEST_TYPE=core travis
+          make TEST_TYPE=plugin travis
+        else
+          make TEST_TYPE=coverage travis || true
+          make TEST_TYPE=integration travis || true
+          make TEST_TYPE=core travis || true
+          make TEST_TYPE=plugin travis || true
+        fi
+      fi
+
+      
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true
@@ -56,9 +70,13 @@ container:
   tags:
     - aufs
   script:
-    - IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}
-    - cp build/Linux/coredns . || true
-    - cp build/linux/amd64/coredns . || true
+    - >
+      if [ "$ARCH" == "arm64" ]; then
+        echo 'ARCH set to arm64'
+        export IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.arm64
+      else
+        echo 'Default to amd64 (Intel)'
+        export IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.amd64
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
     - docker build --pull -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG"


### PR DESCRIPTION
This request is needed for https://github.com/crosscloudci/ci_status_repository/pull/18