### PR TITLE
enable CoreDNS v1.5.1 on cidev

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64" 
-  stable_ref: "v1.5.0"
+  stable_ref: "v1.5.1"
   head_ref: "master"


### PR DESCRIPTION
- enable CoreDNS v1.5.1 (released 5 days ago)