### PR TITLE
Enable CoreDNS v1.5.2 to production

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,8 +24,6 @@ before_script:
 compile:
   image: crosscloudci/debian-go
   stage: build
-  tags:
-    - aufs
   script:
     - mkdir -p /go/src/github.com/coredns
     - ln -s $(pwd) /go/src/github.com/coredns
@@ -66,8 +64,6 @@ compile:
 container:
   image: crosscloudci/debian-docker 
   stage: package
-  tags:
-    - aufs
   script:
     - >
       if [ "$ARCH" == "arm64" ]; then

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,3 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64" 
+  stable_ref: "v1.5.0"
+  head_ref: "master"

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64" 
-  stable_ref: "v1.5.0"
+  stable_ref: "v1.5.2"
   head_ref: "master"


### PR DESCRIPTION
- Enable CoreDNS v1.5.2 on production (cncf.ci) via coredns-configuration production branch
- https://github.com/crosscloudci/crosscloudci/issues/159