### PR TITLE
enable CoreDNS v1.6.0 on dev

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64" 
-  stable_ref: "v1.5.2"
+  stable_ref: "v1.6.0"
   head_ref: "master"


### PR DESCRIPTION
- enable CoreDNS v1.6.0
- released June 28, 2019