### PR TITLE
enable CoreDNS v1.6.2 on staging

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64" 
-  stable_ref: "v1.6.0"
+  stable_ref: "v1.6.1"
   head_ref: "master"

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64" 
-  stable_ref: "v1.6.1"
+  stable_ref: "v1.6.2"
   head_ref: "master"


### PR DESCRIPTION
- enable CoreDNS v1.6.2
- released on Aug 14, 2019