### PR TITLE
enable CoreDNS v1.6.5 on dev

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64" 
-  stable_ref: "v1.6.4"
+  stable_ref: "v1.6.5"
   head_ref: "master"


### PR DESCRIPTION
enable CoreDNS v1.6.5
- released on Nov 5, 2019