### PR TITLE
Feat(chaos-stage)Adding chaos stage to coreDNS pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,3 +87,44 @@ container:
     expire_in: 5 weeks
     paths:
       - release.env
+chaos:
+  stage: test
+  image: ubuntu
+  script:
+    - apt-get update && apt-get install docker.io -y && apt-get install curl -y && apt-get install wget
+    - service docker start
+    - docker version
+    - wget https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz && tar zxf go1.13.5.linux-amd64.tar.gz -C /usr/local/
+    - export PATH=$PATH:/usr/local/go/bin
+    - GO111MODULE="on" go get sigs.k8s.io/kind@v0.6.1 && export PATH=$PATH:~/go/bin
+    - kind version
+    - kind create cluster --loglevel debug
+    - kubectl get nodes
+    - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+    - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl
+    - chmod +x ./kubectl
+    - mv ./kubectl /usr/local/bin/kubectl
+    - kubectl version
+    - kubectl set image deployment/coredns -n kube-system coredns="$CI_REGISTRY_IMAGE:$IMAGE_TAG"
+    - kubectl get pods -n kube-system
+    - kubectl apply -f https://litmuschaos.github.io/pages/litmus-operator-v1.1.0.yaml
+    - sleep 40
+    - kubectl get pods -n litmus
+    - kubectl annotate deploy/coredns -n kube-system litmuschaos.io/chaos="true"
+    - kubectl apply -f https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/coredns/coredns-pod-delete/rbac.yaml
+    - kubectl apply -f https://hub.litmuschaos.io/api/chaos?file=charts/coredns/experiments.yaml -n kube-system
+    - kubectl apply -f https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/coredns/coredns-pod-delete/engine.yaml
+    - sleep 145
+    - kubectl get pods -n kube-system
+    - kubectl logs -f -l name=coredns-pod-delete -n kube-system
+    - kubectl logs -f engine-coredns-runner -n kube-system
+    - kubectl get chaosresult  -n kube-system
+    - verdict=$(kubectl get chaosresult engine-coredns-coredns-pod-delete -n kube-system -o jsonpath='{.status.experimentstatus.verdict}')
+    - >
+      if [ "$verdict" == "pass" ]; then
+        kind delete cluster
+        exit 0;    
+      else
+        kind delete cluster
+        exit 1;           
+      fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 stages:
   - build
   - package
+  - test
 
 before_script:
   - export BASE_URL=${BASE_URL:-$(echo $CI_PROJECT_URL |  cut -d'/' -f1-3)}
@@ -92,39 +93,64 @@ chaos:
   image: ubuntu
   script:
     - apt-get update && apt-get install docker.io -y && apt-get install curl -y && apt-get install wget
-    - service docker start
     - docker version
-    - wget https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz && tar zxf go1.13.5.linux-amd64.tar.gz -C /usr/local/
-    - export PATH=$PATH:/usr/local/go/bin
-    - GO111MODULE="on" go get sigs.k8s.io/kind@v0.6.1 && export PATH=$PATH:~/go/bin
+    # Installing KIND cluster to run the chaos experiments
+    - if [ "$ARCH" == "arm64" ]; then
+        echo 'ARCH set to arm64';
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-$(uname)-arm64;
+      else
+        echo 'Default to amd64 (Intel)';
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-$(uname)-amd64;
+      fi
+    - chmod +x ./kind
+    - mv ./kind /usr/local/bin/kind
     - kind version
     - kind create cluster --loglevel debug
-    - kubectl get nodes
-    - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-    - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl
+    - if [ "$ARCH" == "arm64" ]; then
+        echo 'ARCH set to arm64';
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/arm64/kubectl;
+      else
+        echo 'Default to amd64 (Intel)';
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl;
+      fi
     - chmod +x ./kubectl
     - mv ./kubectl /usr/local/bin/kubectl
     - kubectl version
+    - kubectl get nodes
+    # Replacing CoreDNS image with the latest build image
     - kubectl set image deployment/coredns -n kube-system coredns="$CI_REGISTRY_IMAGE:$IMAGE_TAG"
     - kubectl get pods -n kube-system
+
+    # Running CoreDNS Pod Delete chaos experiment using Litmus
+    # Documentation- https://docs.litmuschaos.io/docs/coredns-pod-delete/
+    # Chaos Hub- https://hub.litmuschaos.io/charts/coredns/experiments/coredns-pod-delete
+
     - kubectl apply -f https://litmuschaos.github.io/pages/litmus-operator-v1.2.0.yaml
-    - sleep 40
     - kubectl get pods -n litmus
     - kubectl annotate deploy/coredns -n kube-system litmuschaos.io/chaos="true"
+    # Applying RBAC spec with with [ services", "pods","jobs","events","pods/log","chaosengines","chaosexperiments","chaosresults"] resource permission
     - kubectl apply -f https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/coredns/coredns-pod-delete/rbac.yaml
+    # Installing CoreDNS pod Delete experiment from the chaoshub
     - kubectl apply -f https://hub.litmuschaos.io/api/chaos?file=charts/coredns/experiments.yaml -n kube-system
+    # Applying chaos engine to the experiment
     - kubectl apply -f https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/coredns/coredns-pod-delete/engine.yaml
-    - sleep 145
+    # Waiting until the coredns experiment job pod is in Ready state
+    - >
+      while [[ $(kubectl get pods -l name=coredns-pod-delete -n kube-system -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do 
+        echo "waiting for pod" && sleep 5; 
+      done
+    # Waiting until the chaos engine pod is deleted
+    - kubectl wait --timeout=-1s --for=delete pod -l app=engine-coredns -n kube-system
     - kubectl get pods -n kube-system
-    - kubectl logs -f -l name=coredns-pod-delete -n kube-system
-    - kubectl logs -f engine-coredns-runner -n kube-system
-    - kubectl get chaosresult  -n kube-system
+    - kubectl get chaosresult -n kube-system
     - verdict=$(kubectl get chaosresult engine-coredns-coredns-pod-delete -n kube-system -o jsonpath='{.status.experimentstatus.verdict}')
     - >
       if [ "$verdict" == "Pass" ]; then
-        kind delete cluster
+        echo "Chaos Result verdict is Pass for the coreDNS Pod Delete experiment";
+        kind delete cluster;
         exit 0;    
       else
-        kind delete cluster
+        echo "Chaos Result verdict is Fail for the coreDNS Pod Delete experiment";
+        kind delete cluster;
         exit 1;           
       fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,7 @@ chaos:
     - kubectl version
     - kubectl set image deployment/coredns -n kube-system coredns="$CI_REGISTRY_IMAGE:$IMAGE_TAG"
     - kubectl get pods -n kube-system
-    - kubectl apply -f https://litmuschaos.github.io/pages/litmus-operator-v1.1.0.yaml
+    - kubectl apply -f https://litmuschaos.github.io/pages/litmus-operator-v1.2.0.yaml
     - sleep 40
     - kubectl get pods -n litmus
     - kubectl annotate deploy/coredns -n kube-system litmuschaos.io/chaos="true"
@@ -121,7 +121,7 @@ chaos:
     - kubectl get chaosresult  -n kube-system
     - verdict=$(kubectl get chaosresult engine-coredns-coredns-pod-delete -n kube-system -o jsonpath='{.status.experimentstatus.verdict}')
     - >
-      if [ "$verdict" == "pass" ]; then
+      if [ "$verdict" == "Pass" ]; then
         kind delete cluster
         exit 0;    
       else


### PR DESCRIPTION
Signed-off-by: Raj <raj.das@mayadata.io>
Issue- https://github.com/crosscloudci/coredns-configuration/issues/41
- Adding the chaos stage for coreDNS test cases.
- Adding the coreDNS pod delete experiment using litmus to check the resiliency of the application