### PR TITLE
Update coredns stable to v1.7.1 on staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ before_script:
   - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
 
 compile:
-  image: crosscloudci/debian-go
+  image: crosscloudci/debian-go:1.13.1-stretch
   stage: build
   script:
     - mkdir -p /go/src/github.com/coredns


### PR DESCRIPTION
## Description
- v1.7.1 was released on 09/21/2020
- update stable on staging; passes on dev manually and trigger on cidev: https://gitlab.cidev.cncf.ci/coredns/coredns/-/jobs/194639

## Issues:
https://github.com/vulk/cncf_ci/issues/69

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [x]  Manually tested pipleline on dev.cncf.ci
 - [x]  Tested with trigger client against
   - [x]  cidev.cncf.ci
   - [ ]  dev.cncf.ci
   - [ ]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [x]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
